### PR TITLE
task/task.json - fixed typo in aipOutputFolder helpMarkDown

### DIFF
--- a/task/task.json
+++ b/task/task.json
@@ -84,7 +84,7 @@
       "defaultValue": "",
       "required": "false",
       "groupName": "advancedBuildSettings",
-      "helpMarkDown": "The result package location. You can specify either an ansolute path or a pertial one, relative to the repository source."
+      "helpMarkDown": "The result package location. You can specify either an absolute path or a partial one, relative to the repository source."
     },
     {
       "name": "aipExtraCommands",


### PR DESCRIPTION
This PR fixes two typos in the AipOutputFolder helpMarkdown.

Noticed this when working on a pipeline this morning.